### PR TITLE
ECS-46 - Better handle expected back end errors

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,8 +4,6 @@ import {
   Body,
   Controller,
   Get,
-  HttpException,
-  HttpStatus,
   Post,
   Req,
   UseGuards,
@@ -41,21 +39,8 @@ export class AuthController {
 
   @Post('register')
   @ApiCreatedResponse({ type: AuthEntity })
-  async register(@Body() { email, password, username }: RegisterDto) {
-    try {
-      return await this.authService.register(email, password, username);
-    } catch (error) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          error: 'Error in registration form',
-        },
-        HttpStatus.BAD_REQUEST,
-        {
-          cause: error,
-        },
-      );
-    }
+  register(@Body() { email, password, username }: RegisterDto) {
+    return this.authService.register(email, password, username);
   }
 
   @Get('status')

--- a/src/auth/auth.exception.ts
+++ b/src/auth/auth.exception.ts
@@ -1,0 +1,28 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class DuplicateUsernameException extends HttpException {
+  constructor() {
+    super('This username is already in use.', HttpStatus.CONFLICT);
+  }
+}
+
+export class DuplicateEmailException extends HttpException {
+  constructor() {
+    super('This email address is already in use.', HttpStatus.CONFLICT);
+  }
+}
+
+export class InvalidCredentialsException extends HttpException {
+  constructor() {
+    super('Invalid username or password', HttpStatus.UNAUTHORIZED);
+  }
+}
+
+export class TraditionalLoginWithOauthException extends HttpException {
+  constructor() {
+    super(
+      "Can't use traditional login with Google account.",
+      HttpStatus.FORBIDDEN,
+    );
+  }
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  IsStrongPassword,
+  MinLength,
+} from 'class-validator';
 
 export class RegisterDto {
   @IsEmail()
@@ -16,6 +22,13 @@ export class RegisterDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
+  @IsStrongPassword({
+    minLength: 8,
+    minNumbers: 1,
+    minSymbols: 1,
+    minLowercase: 1,
+    minUppercase: 1,
+  })
   @ApiProperty()
   password: string;
 }

--- a/src/http-exception-filter/http-exception.filter.ts
+++ b/src/http-exception-filter/http-exception.filter.ts
@@ -13,9 +13,11 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
     const status = exception.getStatus();
+    const message = exception.message;
 
     response.status(status).json({
       statusCode: status,
+      message,
       timestamp: new Date().toISOString(),
       path: request.url,
     });

--- a/src/prisma-client-exception/prisma-client-exception.filter.ts
+++ b/src/prisma-client-exception/prisma-client-exception.filter.ts
@@ -20,6 +20,15 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
         });
         break;
       }
+      // Foreign key constraint violation
+      case 'P2003': {
+        const status = HttpStatus.CONFLICT;
+        response.status(status).json({
+          statusCode: status,
+          message,
+        });
+        break;
+      }
       default:
         super.catch(exception, host);
         break;


### PR DESCRIPTION
Add custom exception types and defer re-throwing to global filter
- Add new auth exceptions that extend `HttpException` and hold consistent error messages for comparable exception types
- Remove the now obsolete step of catching and re-throwing exceptions in the endpoint controller classes
  - instead, these are globally caught by `HttpExceptionFilter` and gracefully re-thrown there.