### PR TITLE
ECS-11-Storage-Backend - Improve cache control

### DIFF
--- a/src/images/images.module.ts
+++ b/src/images/images.module.ts
@@ -1,4 +1,9 @@
+import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { redisStore } from 'cache-manager-redis-store';
+import { NestMinioModule } from 'nestjs-minio';
+
 import { ImagesService } from './images.service';
 import { ImagesController } from './images.controller';
 import { PrismaModule } from '../prisma/prisma.module';
@@ -6,6 +11,41 @@ import { PrismaModule } from '../prisma/prisma.module';
 @Module({
   controllers: [ImagesController],
   providers: [ImagesService],
-  imports: [PrismaModule],
+  imports: [
+    PrismaModule,
+
+    // register the redis cache asynchronously with the connection data from an injected config service.
+    CacheModule.registerAsync({
+      // imports: [ImagesModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const store = await redisStore({
+          socket: {
+            host: configService.get<string>('REDIS_HOST'),
+            port: parseInt(configService.get<string>('REDIS_PORT'), 10),
+          },
+          username: configService.get<string>('REDIS_USERNAME'),
+          password: configService.get<string>('REDIS_PASSWORD'),
+        });
+        return {
+          store: () => store,
+          ttl: 5000,
+        };
+      },
+    }),
+
+    // register S3 file storage module
+    NestMinioModule.registerAsync({
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => ({
+        // otherwise, get S3 data from environment variables and connect to the bucket
+        endPoint: configService.get<string>('S3_ENDPOINT'),
+        port: parseInt(configService.get<string>('S3_PORT'), 10),
+        useSSL: true,
+        accessKey: configService.get<string>('S3_ACCESS_KEY'),
+        secretKey: configService.get<string>('S3_SECRET_KEY'),
+      }),
+    }),
+  ],
 })
 export class ImagesModule {}

--- a/src/images/images.service.ts
+++ b/src/images/images.service.ts
@@ -1,16 +1,27 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Cache, CACHE_MANAGER } from '@nestjs/cache-manager';
+import { NestMinioService } from 'nestjs-minio';
+import { Image, ImageType } from '@prisma/client';
 
-import { Role } from '../roles-guard/role.enum';
-import { PrismaService } from '../prisma/prisma.service';
 import { CreateImageDto } from './dto/create-image.dto';
 import { UpdateImageDto } from './dto/update-image.dto';
-import { NestMinioService } from 'nestjs-minio';
+import { PrismaService } from '../prisma/prisma.service';
+import { Role } from '../roles-guard/role.enum';
 import { MinioError } from './storage.error';
-import { ImageType } from '@prisma/client';
 
 @Injectable()
 export class ImagesService {
+  // URLs from MinIO expire after 24 hours.
+  // Set cache expiry to the same value so that the cache always misses expired URLs.
+  private readonly minioUrlTTL = 24 * 60 * 60;
+
   constructor(
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     private readonly prisma: PrismaService,
     private readonly minioService: NestMinioService,
   ) {}
@@ -22,7 +33,7 @@ export class ImagesService {
   async findAll(userId: number) {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
     if (!user.roles.includes(Role.Admin)) {
-      return this.prisma.image.findMany({
+      const images = await this.prisma.image.findMany({
         where: {
           draftPlayer: {
             enrollment: {
@@ -31,8 +42,11 @@ export class ImagesService {
           },
         },
       });
+      return this.mapUrlsToImages(images);
     }
-    return this.prisma.image.findMany();
+
+    const images = await this.prisma.image.findMany();
+    return this.mapUrlsToImages(images);
   }
 
   async handleUpload(
@@ -42,12 +56,8 @@ export class ImagesService {
     checkin: boolean,
   ) {
     const client = this.minioService.getMinio();
-    const metaData = {
-      'Content-Type': file.mimetype,
-      'X-Amz-Meta-Timestamp': new Date().toISOString(),
-      'X-Amz-Meta-UserId': `${userId}`,
-    };
 
+    // Find the draft player for the current user that is in an ongoing draft
     const player = await this.prisma.draftPlayer.findFirst({
       where: {
         enrollment: {
@@ -63,18 +73,39 @@ export class ImagesService {
         id: true,
         checkedIn: true,
         checkedOut: true,
+        draft: {
+          select: {
+            phase: { select: { phaseIndex: true } },
+            cube: { select: { name: true } },
+          },
+        },
         enrollment: {
           select: {
-            user: {
-              select: { username: true },
-            },
+            user: { select: { username: true } },
           },
         },
       },
     });
 
-    const filename = `${player.enrollment.user.username}-${new Date().toISOString()}.jpg`;
+    // Construct the filename for S3 as:
+    // <username>-phase<phaseIndex>-<cube>-<checkin/checkout>.jpg
+    // for example: paul-phase1-shivan-checkin.jpg
+    const cube = player.draft.cube.name.toLowerCase();
+    const phaseIdx = player.draft.phase.phaseIndex;
+    const username = player.enrollment.user.username.toLowerCase();
+    const checkInStr = checkin ? 'checkin' : 'checkout';
 
+    // Define image metadata
+    const metaData = {
+      'Content-Type': file.mimetype,
+      'X-Amz-Meta-Timestamp': new Date().toISOString(),
+      'X-Amz-Meta-Imagetype': `${checkInStr}`,
+      'X-Amz-Meta-Cube': `${cube}`,
+    };
+
+    const filename = `${username}-phase${phaseIdx}-${cube}-${checkInStr}.jpg`;
+
+    // Try to upload the image to S3 storage
     try {
       await client.putObject(
         'user-upload',
@@ -92,6 +123,7 @@ export class ImagesService {
       ? ImageType.CHECKIN
       : ImageType.CHECKOUT;
 
+    // Create the `Image` database object
     await this.prisma.image.create({
       data: {
         draftPlayerId: player.id,
@@ -104,8 +136,11 @@ export class ImagesService {
       const url = await client.presignedGetObject(
         'user-upload',
         filename,
-        24 * 60 * 60,
+        this.minioUrlTTL,
       );
+      // Set the URL into cache for 24 hrs
+      await this.cacheManager.set(filename, url, this.minioUrlTTL * 1000);
+
       return { url };
     } catch (error) {
       console.error('MinIO error:', error);
@@ -125,24 +160,16 @@ export class ImagesService {
     });
 
     if (!images) {
-      return [];
+      throw new NotFoundException('No images found for user');
     }
 
-    const client = this.minioService.getMinio();
-    const ret = [];
-    for (const image of images) {
-      const url = await client.presignedGetObject(
-        'user-upload',
-        image.storagePath,
-        24 * 60 * 60,
-      );
-      ret.push({ id: image.id, url });
-    }
-    return ret;
+    // Return only image IDs and their pre-signed URLs for front end usage.
+    return this.mapUrlsToImages(images);
   }
 
   async findOne(id: number, userId: number) {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
+
     if (!user.roles.includes(Role.Admin)) {
       const image = await this.prisma.image.findUnique({
         where: { id },
@@ -169,6 +196,7 @@ export class ImagesService {
 
   async update(id: number, updateImageDto: UpdateImageDto, userId: number) {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
+
     if (!user.roles.includes(Role.Admin)) {
       const image = await this.prisma.image.findUnique({
         where: { id },
@@ -190,32 +218,72 @@ export class ImagesService {
         );
       }
     }
+
     return this.prisma.image.update({ where: { id }, data: updateImageDto });
   }
 
   async remove(id: number, userId: number) {
     const user = await this.prisma.user.findUnique({ where: { id: userId } });
-    if (!user.roles.includes(Role.Admin)) {
-      const image = await this.prisma.image.findUnique({
-        where: { id },
-        include: {
-          draftPlayer: {
-            select: {
-              enrollment: {
-                select: {
-                  userId: true,
-                },
+
+    const image = await this.prisma.image.findUnique({
+      where: { id },
+      include: {
+        draftPlayer: {
+          select: {
+            enrollment: {
+              select: {
+                userId: true,
               },
             },
           },
         },
-      });
+      },
+    });
+
+    if (!user.roles.includes(Role.Admin)) {
       if (image.draftPlayer.enrollment.userId !== userId) {
         throw new UnauthorizedException(
           'User is not authorized to delete this image',
         );
       }
     }
+
+    await this.cacheManager.del(image.storagePath);
     return this.prisma.image.delete({ where: { id } });
+  }
+
+  // Gets the pre-signed URL for each image object.
+  // Attempts to get these from cache first and queries them from MinIO on cache miss.
+  private async mapUrlsToImages(
+    images: Image[],
+  ): Promise<{ id: number; url: string }[]> {
+    const client = this.minioService.getMinio();
+
+    const urls = await Promise.all(
+      images.map(async (image) => {
+        // Check the cache for a valid URL for this image
+        let url = await this.cacheManager.get<string>(image.storagePath);
+
+        // On cache miss, query the URL from MinIO and set it into cache.
+        if (!url) {
+          url = await client.presignedGetObject(
+            'user-upload',
+            image.storagePath,
+            this.minioUrlTTL,
+          );
+          await this.cacheManager.set(
+            image.storagePath,
+            url,
+            this.minioUrlTTL * 1000,
+          );
+        }
+
+        return {
+          id: image.id,
+          url,
+        };
+      }),
+    );
+    return urls;
   }
 }


### PR DESCRIPTION
Register cache manager on module level, add image URL caching
- Moved providing `CacheModule` and `NestMinioModule` from a global registration in `AppModule` to a local one in `ImagesModule` since that's currently the only place where they are actually being used.
- Each image upload now creates a pre-signed URL from MinIO with a 24 hour expiry time and caches it in Redis for the same amount of time.
  - GET requests to any image endpoint now first query Redis for any image URLs
- The DELETE endpoint now removes images from MinIO and the DB and clears the associated cache entry in Redis.