### PR TITLE
ECS-48 - Check in/Check out

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,7 +90,7 @@ model Phase {
   tournament   Tournament @relation(fields: [tournamentId], references: [id])
   tournamentId Int
   phaseIndex   Int
-  roundAmount  Int        @default(3)
+  numRounds    Int        @default(3) @map("roundAmount")
   started      Boolean    @default(false)
   finished     Boolean    @default(false)
   drafts       Draft[]

--- a/src/matches/matches.service.ts
+++ b/src/matches/matches.service.ts
@@ -117,6 +117,11 @@ export class MatchesService {
             },
           },
         },
+        round: {
+          select: {
+            roundIndex: true,
+          },
+        },
       },
     });
     if (!game) {
@@ -327,7 +332,7 @@ export class MatchesService {
       where: { id: draftId },
       include: {
         phase: {
-          select: { roundAmount: true },
+          select: { numRounds: true },
         },
       },
     });

--- a/src/phases/dto/create-phase.dto.ts
+++ b/src/phases/dto/create-phase.dto.ts
@@ -16,7 +16,7 @@ export class CreatePhaseDto {
   @IsPositive()
   @IsOptional()
   @ApiProperty({ required: false, default: 3 })
-  roundAmount: number;
+  numRounds: number;
 
   @IsBoolean()
   @IsOptional()

--- a/src/phases/entities/phase.entity.ts
+++ b/src/phases/entities/phase.entity.ts
@@ -12,7 +12,7 @@ export class PhaseEntity implements Phase {
   phaseIndex: number;
 
   @ApiProperty()
-  roundAmount: number;
+  numRounds: number;
 
   @ApiProperty()
   started: boolean;

--- a/src/phases/phases.service.ts
+++ b/src/phases/phases.service.ts
@@ -8,11 +8,11 @@ export class PhasesService {
   constructor(private prisma: PrismaService) {}
 
   async createWithoutPhaseIndex(data: Partial<CreatePhaseDto>) {
-    const { tournamentId, roundAmount } = data;
+    const { tournamentId, numRounds } = data;
 
     let createPhaseDto: CreatePhaseDto = {
       tournamentId,
-      roundAmount,
+      numRounds,
       phaseIndex: 0,
     };
 
@@ -51,7 +51,7 @@ export class PhasesService {
       },
       select: {
         id: true,
-        roundAmount: true,
+        numRounds: true,
         phaseIndex: true,
         tournament: {
           select: {


### PR DESCRIPTION
- Add `needsCheckin` and `needsCheckout` to `getCurrentDraft(userId)` endpoint:
  - Finally rename `roundAmount` field on `Phase` model to `numRounds`
  - Query need for check in and check out during current draft fetching:
    - if the draft is not yet seated, neither is needed
    - if the draft is seated, check in is needed, unless
    - if the current match is the last one and its result is confirmed, check out is needed
- Image creation rollback on S3 failure
  - Delete the newly created image if the S3 upload failed